### PR TITLE
Raise appropriate error on unknown topic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:2.3.1-alpine
+MAINTAINER Code Climate <hello@codeclimate.com>
+
+RUN apk --update add git build-base autoconf automake libtool ruby-dev ruby-bundler snappy openjdk8 && \
+  rm -fr /usr/share/ri
+
+ENV KAFKA_SRC=http://apache.cs.utah.edu/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz
+ENV KAFKA_PATH=/usr/src/kafka
+
+RUN curl "$KAFKA_SRC" | tar xvzf - && mv kafka_* "$KAFKA_PATH"
+
+WORKDIR /usr/src/poseidon/
+
+COPY .git/ /usr/src/poseidon/
+COPY Gemfile* /usr/src/poseidon/
+COPY poseidon.gemspec /usr/src/poseidon/
+COPY lib/poseidon/version.rb /usr/src/poseidon/lib/poseidon/
+
+RUN bundle install -j 4
+
+COPY . /usr/src/poseidon/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.3.1-alpine
 MAINTAINER Code Climate <hello@codeclimate.com>
 
-RUN apk --update add git build-base autoconf automake libtool ruby-dev ruby-bundler snappy openjdk8 && \
+RUN apk --update add curl git build-base autoconf automake libtool ruby-dev ruby-bundler snappy openjdk8 && \
   rm -fr /usr/share/ri
 
 ENV KAFKA_SRC=http://apache.cs.utah.edu/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: image test
+
+image:
+	docker build -t codeclimate/codeclimate-poseidon .
+
+test: image
+	docker run --rm -t codeclimate/codeclimate-poseidon bundle exec rake spec:all

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,8 @@ machine:
   environment:
     KAFKA_SRC: http://apache.cs.utah.edu/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz
     KAFKA_PATH: /tmp/kafka
+  ruby:
+    version: ruby-2.0
 
 dependencies:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,13 @@
+machine:
+  environment:
+    KAFKA_SRC: http://apache.cs.utah.edu/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz
+    KAFKA_PATH: /tmp/kafka
+
+dependencies:
+  pre:
+    - curl "$KAFKA_SRC" | tar xvzf -
+    - mv kafka_* "$KAFKA_PATH"
+
+test:
+  override:
+    - bundle exec rake spec:all

--- a/circle.yml
+++ b/circle.yml
@@ -1,15 +1,11 @@
 machine:
-  environment:
-    KAFKA_SRC: http://apache.cs.utah.edu/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz
-    KAFKA_PATH: /tmp/kafka
-  ruby:
-    version: ruby-2.0
+  services:
+    - docker
 
 dependencies:
-  pre:
-    - curl "$KAFKA_SRC" | tar xvzf -
-    - mv kafka_* "$KAFKA_PATH"
+  override:
+    - make image
 
 test:
   override:
-    - bundle exec rake spec:all
+    - make test

--- a/lib/poseidon.rb
+++ b/lib/poseidon.rb
@@ -62,6 +62,9 @@ module Poseidon
       10 => MessageSizeTooLarge
     }
 
+    # Raised when messages were not successfully produced to Kafka
+    class MessageDeliveryError < StandardError; end
+
     # Raised when a custom partitioner tries to send
     # a message to a partition that doesn't exist.
     class InvalidPartitionError < StandardError; end

--- a/lib/poseidon/broker_pool.rb
+++ b/lib/poseidon/broker_pool.rb
@@ -1,6 +1,6 @@
 module Poseidon
   # BrokerPool allows you to send api calls to the a brokers Connection.
-  # 
+  #
   # @api private
   class BrokerPool
     class UnknownBroker < StandardError; end
@@ -26,7 +26,7 @@ module Poseidon
     def fetch_metadata(topics)
       @seed_brokers.each do |broker|
         if metadata = fetch_metadata_from_broker(broker, topics)
-          Poseidon.logger.debug { "Fetched metadata\n" + metadata.to_s }
+          Poseidon.logger.debug { "Fetched metadata from #{broker}:\n" + metadata.to_s }
           return metadata
         end
       end

--- a/lib/poseidon/cluster_metadata.rb
+++ b/lib/poseidon/cluster_metadata.rb
@@ -49,6 +49,8 @@ module Poseidon
 
     # Return lead broker for topic and partition
     def lead_broker_for_partition(topic_name, partition)
+      raise ::Poseidon::Errors::UnknownTopicOrPartition unless @topic_metadata[topic_name]
+
       broker_id = @topic_metadata[topic_name].partition_leader(partition)
       if broker_id
         @brokers[broker_id]

--- a/lib/poseidon/cluster_metadata.rb
+++ b/lib/poseidon/cluster_metadata.rb
@@ -71,6 +71,11 @@ module Poseidon
       out
     end
 
+    def reset
+      @brokers        = {}
+      @topic_metadata = {}
+    end
+
     private
     def update_topics(topics)
       topics.each do |topic|

--- a/lib/poseidon/connection.rb
+++ b/lib/poseidon/connection.rb
@@ -135,7 +135,7 @@ module Poseidon
       buffer = Protocol::RequestBuffer.new
       request.write(buffer)
       ensure_write_or_timeout([buffer.to_s.bytesize].pack("N") + buffer.to_s)
-    rescue Errno::EPIPE, Errno::ECONNRESET, TimeoutException => ex
+    rescue Errno::EPIPE, Errno::ECONNRESET, Errno::ETIMEDOUT, TimeoutException => ex
       @socket = nil
       raise_connection_failed_from_exception(ex)
     end

--- a/lib/poseidon/sync_producer.rb
+++ b/lib/poseidon/sync_producer.rb
@@ -100,14 +100,14 @@ module Poseidon
       @socket_timeout_ms = handle_option(options, :socket_timeout_ms)
       @retry_backoff_ms  = handle_option(options, :retry_backoff_ms)
 
-      @metadata_refresh_interval_ms = 
+      @metadata_refresh_interval_ms =
         handle_option(options, :metadata_refresh_interval_ms)
 
       @required_acks    = handle_option(options, :required_acks)
       @max_send_retries = handle_option(options, :max_send_retries)
 
       @compression_config = ProducerCompressionConfig.new(
-        handle_option(options, :compression_codec), 
+        handle_option(options, :compression_codec),
         handle_option(options, :compressed_topics))
 
       @partitioner = handle_option(options, :partitioner)

--- a/lib/poseidon/sync_producer.rb
+++ b/lib/poseidon/sync_producer.rb
@@ -156,7 +156,7 @@ module Poseidon
         messages_for_broker.successfully_sent(response)
       end
     rescue Connection::ConnectionFailedError
-      Poseidon.logger.debug { "Failed to send messages to #{messages_for_broker.broker_id} due to connection failure"  }
+      Poseidon.logger.warn { "Failed to send messages to #{messages_for_broker.broker_id} due to connection failure"  }
       false
     end
   end

--- a/lib/poseidon/sync_producer.rb
+++ b/lib/poseidon/sync_producer.rb
@@ -65,7 +65,7 @@ module Poseidon
       end
 
       if messages_to_send.pending_messages?
-        raise "Failed to send all messages: #{messages_to_send.messages} remaining"
+        raise Errors::MessageDeliveryError, "Failed to send all messages: #{messages_to_send.messages} remaining"
       else
         true
       end

--- a/lib/poseidon/sync_producer.rb
+++ b/lib/poseidon/sync_producer.rb
@@ -57,6 +57,7 @@ module Poseidon
         if !messages_to_send.pending_messages? || @max_send_retries == 0
           break
         else
+          Poseidon.logger.debug { "retrying sending #{messages_to_send.messages} messages"  }
           Kernel.sleep retry_backoff_ms / 1000.0
           reset_metadata
           ensure_metadata_available_for_topics(messages_to_send)
@@ -155,6 +156,7 @@ module Poseidon
         messages_for_broker.successfully_sent(response)
       end
     rescue Connection::ConnectionFailedError
+      Poseidon.logger.debug { "Failed to send messages to #{messages_for_broker.broker_id} due to connection failure"  }
       false
     end
   end

--- a/lib/poseidon/sync_producer.rb
+++ b/lib/poseidon/sync_producer.rb
@@ -155,8 +155,8 @@ module Poseidon
       else
         messages_for_broker.successfully_sent(response)
       end
-    rescue Connection::ConnectionFailedError
-      Poseidon.logger.warn { "Failed to send messages to #{messages_for_broker.broker_id} due to connection failure"  }
+    rescue Connection::ConnectionFailedError => ex
+      Poseidon.logger.warn { "Failed to send messages to #{messages_for_broker.broker_id} due to connection failure: message=#{ex.message}" }
       false
     end
   end

--- a/lib/poseidon/topic_metadata.rb
+++ b/lib/poseidon/topic_metadata.rb
@@ -35,7 +35,7 @@ module Poseidon
     end
 
     def exists?
-      struct.error == 0
+      struct.error == Errors::NO_ERROR_CODE
     end
 
     def eql?(o)
@@ -56,7 +56,7 @@ module Poseidon
 
     def available_partitions
       @available_partitions ||= struct.partitions.select do |partition|
-        partition.error == 0 && partition.leader != -1
+        (partition.error == Errors::NO_ERROR_CODE || partition.error_class == Errors::ReplicaNotAvailable) && partition.leader != -1
       end
     end
 

--- a/lib/poseidon/version.rb
+++ b/lib/poseidon/version.rb
@@ -1,4 +1,4 @@
 module Poseidon
   # Unstable! API May Change!
-  VERSION = "0.0.6"
+  VERSION = "0.0.8"
 end

--- a/lib/poseidon/version.rb
+++ b/lib/poseidon/version.rb
@@ -1,4 +1,4 @@
 module Poseidon
   # Unstable! API May Change!
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end

--- a/lib/poseidon/version.rb
+++ b/lib/poseidon/version.rb
@@ -1,4 +1,4 @@
 module Poseidon
   # Unstable! API May Change!
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/lib/poseidon/version.rb
+++ b/lib/poseidon/version.rb
@@ -1,4 +1,4 @@
 module Poseidon
   # Unstable! API May Change!
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end

--- a/lib/poseidon/version.rb
+++ b/lib/poseidon/version.rb
@@ -1,4 +1,4 @@
 module Poseidon
   # Unstable! API May Change!
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/lib/poseidon/version.rb
+++ b/lib/poseidon/version.rb
@@ -1,4 +1,4 @@
 module Poseidon
   # Unstable! API May Change!
-  VERSION = "0.0.11"
+  VERSION = "0.0.12"
 end

--- a/poseidon.gemspec
+++ b/poseidon.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'poseidon/version'
 
 Gem::Specification.new do |gem|
-  gem.name          = "poseidon"
+  gem.name          = "codeclimate-poseidon"
   gem.version       = Poseidon::VERSION
   gem.authors       = ["Bob Potter"]
   gem.email         = ["bobby.potter@gmail.com"]

--- a/poseidon.gemspec
+++ b/poseidon.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency(%q<yard>)
   gem.add_development_dependency(%q<simplecov>)
   gem.add_development_dependency(%q<snappy>)
+  gem.add_development_dependency(%q<timecop>)
 end

--- a/spec/integration/multiple_brokers/consumer_spec.rb
+++ b/spec/integration/multiple_brokers/consumer_spec.rb
@@ -1,6 +1,8 @@
 require 'integration/multiple_brokers/spec_helper'
 
 RSpec.describe "consuming with multiple brokers", :type => :request do
+  include_context "a multiple broker cluster"
+
   before(:each) do
     # autocreate the topic by asking for information about it
     c = Connection.new("localhost", 9092, "metadata_fetcher", 10_000)

--- a/spec/integration/multiple_brokers/metadata_failures_spec.rb
+++ b/spec/integration/multiple_brokers/metadata_failures_spec.rb
@@ -1,6 +1,22 @@
 require 'integration/multiple_brokers/spec_helper'
 
+# Created because you can't use a block form for receive with and_call_original
+# https://github.com/rspec/rspec-mocks/issues/774
+RSpec::Matchers.define :a_broker_id_of do |id|
+  match { |actual| actual.broker_id == id }
+end
+
+RSpec::Matchers.define :a_broker_id_not do |id|
+  match { |actual| actual.broker_id != id }
+end
+
+RSpec::Matchers.define :needing_metadata do |val|
+  match { |actual| actual.send(:needs_metadata?) == val }
+end
+
 RSpec.describe "handling failures", :type => :request do
+  include_context "a multiple broker cluster"
+
   describe "metadata failures" do
     before(:each) do
       @messages_to_send = [
@@ -30,6 +46,99 @@ RSpec.describe "handling failures", :type => :request do
       expect {
         @p.send_messages([MessageToSend.new("imnothere", "hello")])
       }.to raise_error(Poseidon::Errors::UnableToFetchMetadata)
+    end
+  end
+
+  describe "leader node loss" do
+    let(:topic) { "testing" }
+    let(:kafka_partitions) { 1 }
+
+    it "is still able to send messages" do
+      @p = Producer.new(["localhost:9092","localhost:9093","localhost:9094"], "producer", :required_acks => 1)
+
+      # Send one to force topic creation
+      expect(@p.send_messages([MessageToSend.new(topic, "hello")])).to be_truthy
+
+      @producer = @p.instance_variable_get(:@producer)
+      @cluster_metadata = @producer.instance_variable_get(:@cluster_metadata)
+      topic_metadata = @cluster_metadata.metadata_for_topics([topic])[topic]
+
+      expect(topic_metadata.available_partitions.length).to be(kafka_partitions)
+
+      # Now, lets kill the topic leader
+      leader = topic_metadata.available_partitions.first.leader
+      broker = $tc.brokers[topic_metadata.available_partitions.first.leader]
+      expect(broker.id).to be(leader)
+
+      broker.without_process do
+        expect(@cluster_metadata.metadata_for_topics([topic])[topic].available_partitions.first.leader).to be(leader)
+        expect(@producer.send(:refresh_interval_elapsed?)).to be_falsy
+
+        # Setup expectations that the consumer updates its info
+        expect(@producer).to receive(:ensure_metadata_available_for_topics).with(needing_metadata(false)).ordered.and_call_original
+        expect(@producer).to receive(:send_to_broker).with(a_broker_id_of(leader)).ordered.and_call_original
+
+        expect(@producer).to receive(:reset_metadata).ordered.and_call_original
+        expect(@producer).to receive(:ensure_metadata_available_for_topics).ordered.and_call_original
+        expect(@producer).to receive(:send_to_broker).with(a_broker_id_not(leader)).ordered.and_call_original
+
+        expect(@p.send_messages([MessageToSend.new(topic, "hello")])).to be_truthy
+      end
+    end
+  end
+
+  describe "partition replica loss" do
+    let(:topic) { "testing" }
+    let(:kafka_partitions) { 1 }
+
+    it "refreshes metadata correctly" do
+      @p = Producer.new(["localhost:9092","localhost:9093","localhost:9094"], "producer", :required_acks => 1)
+
+      # Send one to force topic creation
+      expect(@p.send_messages([MessageToSend.new(topic, "hello")])).to be_truthy
+
+      @producer = @p.instance_variable_get(:@producer)
+      @cluster_metadata = @producer.instance_variable_get(:@cluster_metadata)
+      topic_metadata = @cluster_metadata.metadata_for_topics([topic])[topic]
+
+      expect(topic_metadata.available_partitions.length).to be(kafka_partitions)
+      expect(topic_metadata.available_partitions.first.error).to be(0)
+
+      # Now, lets kill the topic leader
+      partition_metadata = topic_metadata.available_partitions.first
+      expect(partition_metadata.replicas.length).to be(2)
+      leader = partition_metadata.leader
+      replica = (partition_metadata.replicas - [leader]).first
+
+      broker = $tc.brokers[replica]
+      expect(broker.id).to_not be(partition_metadata.leader)
+      expect(broker.id).to be(replica)
+
+      broker.without_process do
+        expect(@cluster_metadata.metadata_for_topics([topic])[topic].available_partitions.first.replicas).to include(replica)
+        expect(@producer.send(:refresh_interval_elapsed?)).to be_falsy
+
+        Timecop.travel(@producer.metadata_refresh_interval_ms) do
+          expect(@producer.send(:refresh_interval_elapsed?)).to be_truthy
+
+          # Setup expectations that the consumer updates its info
+          expect(@producer).to receive(:refresh_metadata).with(Set.new([topic])).ordered.and_call_original
+          expect(@producer).to receive(:ensure_metadata_available_for_topics).with(needing_metadata(false)).ordered.and_call_original
+          expect(@producer).to receive(:send_to_broker).with(a_broker_id_of(partition_metadata.leader)).ordered.and_call_original
+
+          # Make sure we don't error out
+          expect(@producer).to_not receive(:reset_metadata)
+
+          expect(@p.send_messages([MessageToSend.new(topic, "hello")])).to be_truthy
+
+          # Check the valid metadata
+          updated_topic_metadata = @cluster_metadata.metadata_for_topics([topic])[topic]
+          expect(updated_topic_metadata.available_partitions.length).to be(kafka_partitions)
+          expect(updated_topic_metadata.available_partitions.first.leader).to be(leader)
+          expect(updated_topic_metadata.available_partitions.first.replicas).to eq([leader])
+          expect(updated_topic_metadata.available_partitions.first.error).to be(9)
+        end
+      end
     end
   end
 end

--- a/spec/integration/multiple_brokers/rebalance_spec.rb
+++ b/spec/integration/multiple_brokers/rebalance_spec.rb
@@ -1,6 +1,8 @@
 require 'integration/multiple_brokers/spec_helper'
 
 RSpec.describe "producer handles rebalancing", :type => :request do
+  include_context "a multiple broker cluster"
+
   before(:each) do
     # autocreate the topic by asking for information about it
     @c = Connection.new("localhost", 9093, "metadata_fetcher", 10_000)

--- a/spec/integration/multiple_brokers/round_robin_spec.rb
+++ b/spec/integration/multiple_brokers/round_robin_spec.rb
@@ -1,6 +1,8 @@
 require 'integration/multiple_brokers/spec_helper'
 
 RSpec.describe "round robin sending", :type => :request do
+  include_context "a multiple broker cluster"
+
   describe "with small message batches" do
     it "evenly distributes messages across brokers" do
       c = Connection.new("localhost", 9092, "metadata_fetcher", 10_000)

--- a/spec/integration/simple/compression_spec.rb
+++ b/spec/integration/simple/compression_spec.rb
@@ -1,6 +1,8 @@
 require 'integration/simple/spec_helper'
 
 RSpec.describe "compression", :type => :request do
+  include_context "a single broker cluster"
+
   it "roundtrips" do
     i = rand(1000)
 

--- a/spec/integration/simple/connection_spec.rb
+++ b/spec/integration/simple/connection_spec.rb
@@ -2,6 +2,8 @@ require 'integration/simple/spec_helper'
 
 include Protocol
 RSpec.describe Connection, :type => :request do
+  include_context "a single broker cluster"
+
   before(:each) do
     @connection = Connection.new("localhost", 9092, "test", 10_000)
   end

--- a/spec/integration/simple/multiple_brokers_spec.rb
+++ b/spec/integration/simple/multiple_brokers_spec.rb
@@ -1,6 +1,8 @@
 require 'integration/simple/spec_helper'
 
 RSpec.describe "three brokers in cluster", :type => :request do
+  include_context "a single broker cluster"
+
   describe "sending batches of 1 message" do
     it "sends messages to all brokers" do
     end

--- a/spec/integration/simple/simple_producer_and_consumer_spec.rb
+++ b/spec/integration/simple/simple_producer_and_consumer_spec.rb
@@ -1,6 +1,7 @@
 require 'integration/simple/spec_helper'
 
 RSpec.describe "simple producer and consumer", :type => :request do
+  include_context "a single broker cluster"
 
   describe "writing and consuming one topic" do
     it "fetches produced messages" do

--- a/spec/integration/simple/spec_helper.rb
+++ b/spec/integration/simple/spec_helper.rb
@@ -2,16 +2,15 @@ require 'spec_helper'
 
 require 'test_cluster'
 
-RSpec.configure do |config|
-  config.before(:each) do
+RSpec.shared_context "a single broker cluster" do
+  before(:each) do
     JavaRunner.remove_tmp
     JavaRunner.set_kafka_path!
     $tc = TestCluster.new
     $tc.start
-    sleep 5
   end
 
-  config.after(:each) do
+  after(:each) do
     $tc.stop
   end
 end

--- a/spec/integration/simple/truncated_messages_spec.rb
+++ b/spec/integration/simple/truncated_messages_spec.rb
@@ -1,6 +1,8 @@
 require 'integration/simple/spec_helper'
 
 RSpec.describe "truncated messages", :type => :request do
+  include_context "a single broker cluster"
+
   before(:each) do
     @s1 = "a" * 335
     @s2 = "b" * 338

--- a/spec/integration/simple/unavailable_broker_spec.rb
+++ b/spec/integration/simple/unavailable_broker_spec.rb
@@ -1,6 +1,8 @@
 require 'integration/simple/spec_helper'
 
 RSpec.describe "unavailable broker scenarios:", :type => :request do
+  include_context "a single broker cluster"
+
   context "producer with a dead broker in bootstrap list" do
     before(:each) do
       @p = Producer.new(["localhost:9091","localhost:9092"], "test")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,3 +27,6 @@ include Poseidon
 
 require 'coveralls'
 Coveralls.wear!
+
+require 'timecop'
+Timecop.safe_mode = true

--- a/spec/test_cluster.rb
+++ b/spec/test_cluster.rb
@@ -8,6 +8,7 @@ class TestCluster
   def start
     @zookeeper.start
     @broker.start
+    sleep 5
   end
 
   def stop
@@ -153,10 +154,12 @@ class BrokerRunner
     "leader.imbalance.check.interval.seconds" => 5
   }
 
+  attr_reader :id
+
   def initialize(id, port, partition_count = 1, replication_factor = 1, properties = {})
     @id   = id
     @port = port
-    @jr = JavaRunner.new("broker_#{id}", 
+    @jr = JavaRunner.new("broker_#{id}",
                          "#{ENV['KAFKA_PATH']}/bin/kafka-run-class.sh -daemon -name broker_#{id} kafka.Kafka",
                          "ps ax | grep -i 'kafka\.Kafka' | grep java | grep broker_#{id} | grep -v grep | awk '{print $1}'",
                          "SIGTERM",
@@ -197,7 +200,7 @@ class ZookeeperRunner
   def pid
     @jr.pid
   end
-  
+
   def start
     @jr.start
   end

--- a/spec/unit/cluster_metadata_spec.rb
+++ b/spec/unit/cluster_metadata_spec.rb
@@ -42,5 +42,11 @@ RSpec.describe ClusterMetadata do
       expect(@cm.lead_broker_for_partition("test",1).id).to eq(1)
       expect(@cm.lead_broker_for_partition("test",2).id).to eq(2)
     end
+
+    it "raises an UnknownErrorOrPartition when the topic does not exist" do
+      expect {
+        @cm.lead_broker_for_partition("nonsense",1)
+      }.to raise_error(::Poseidon::Errors::UnknownTopicOrPartition)
+    end
   end
 end

--- a/spec/unit/producer_spec.rb
+++ b/spec/unit/producer_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Producer do
   it "requires brokers and client_id" do
-    expect { Producer.new }.to raise_error
+    expect { Producer.new }.to raise_error(ArgumentError)
   end
 
   it "raises ArgumentError on unknown arguments" do

--- a/spec/unit/protocol_spec.rb
+++ b/spec/unit/protocol_spec.rb
@@ -49,6 +49,6 @@ RSpec.describe "objects with errors" do
                                                   [partition_fetch_response])
     response = FetchResponse.new(double('common'), [topic_fetch_response])
 
-    expect { response.raise_error_if_one_exists }.to raise_error
+    expect { response.raise_error_if_one_exists }.to raise_error(Poseidon::Errors::LeaderNotAvailable)
   end
 end

--- a/spec/unit/sync_producer_spec.rb
+++ b/spec/unit/sync_producer_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe SyncProducer do
       it "raises an exception" do
         expect {
           @sp.send_messages([Message.new(:topic => "topic", :value => "value")])
-        }.to raise_error
+        }.to raise_error(Poseidon::Errors::MessageDeliveryError)
       end
     end
 

--- a/spec/unit/topic_metadata_spec.rb
+++ b/spec/unit/topic_metadata_spec.rb
@@ -22,4 +22,22 @@ RSpec.describe TopicMetadata do
 
     expect(tm.partition_leader(0)).to eq(0)
   end
+
+  context "#available_partitions" do
+    it "includes when missing replicas" do
+      partition_metadata = Protocol::PartitionMetadata.new(9, 0, 0, [0], [0])
+      partitions = [partition_metadata]
+      tm = TopicMetadata.new(Protocol::TopicMetadataStruct.new(0, "topic", partitions))
+
+      expect(tm.available_partitions.length).to be(1)
+    end
+
+    it "ignores other errors" do
+      partition_metadata = Protocol::PartitionMetadata.new(2, 0, 0, [0], [0])
+      partitions = [partition_metadata]
+      tm = TopicMetadata.new(Protocol::TopicMetadataStruct.new(0, "topic", partitions))
+
+      expect(tm.available_partitions.length).to be(0)
+    end
+  end
 end


### PR DESCRIPTION
## Expected Behavior
Attempting to fetch from an undefined topic raises a `Poseidon::Errors::UnknownTopicOrPartition` error.

## Actual Behavior
A `NoMethodError` is raised.
```
poseidon/cluster_metadata.rb:52:in `lead_broker_for_partition': undefined method `partition_leader' for nil:NilClass (NoMethodError)
```

The proposed change raises a more specific error which a client can choose to catch and handle.
The use case in mind with this change is an environment allowing Kafka to auto-create topics.
Before the fix, clients would receive a `NoMethodError` when attempting to fetch from a topic that has yet to be created.
With this change applied the client receives an `UnknownTopicOrPartition` error which can be more elegantly handled.